### PR TITLE
Simplify prism module.

### DIFF
--- a/prism.scad
+++ b/prism.scad
@@ -4,12 +4,18 @@
 //w - width of triangle
 //h - height of triangle
 module prism(l, w, h) {
-	translate([0, l, 0]) rotate( a= [90, 0, 0]) 
-	linear_extrude(height = l) polygon(points = [
-		[0, 0],
-		[w, 0],
-		[0, h]
-	], paths=[[0,1,2,0]]);
+       polyhedron(points=[
+               [0,0,h],           // 0    front top corner
+               [0,0,0],[w,0,0],   // 1, 2 front left & right bottom corners
+               [0,l,h],           // 3    back top corner
+               [0,l,0],[w,l,0]    // 4, 5 back left & right bottom corners
+       ], faces=[ // points for all faces must be ordered clockwise when looking in
+               [0,2,1],    // top face
+               [3,4,5],    // base face
+               [0,1,4,3],  // h face
+               [1,2,5,4],  // w face
+               [0,3,5,2],  // hypotenuse face
+       ]);
 }
 
 prism(5, 3, 2);


### PR DESCRIPTION
While it appears to have more lines because of the detailed comments,
using a single polyhedron() call is much less computationally intensive
than chaining translate(), rotate(), linear_extrude(), and polygon().
Since polyhedron() is hard to get right (sometimes they will Preview
[F5] fine but fail to Render [F6] all faces) I am including a more
demonstrative example in this commit message.

```scad
module prism(l, w, h) {
    translate([0, l, 0]) rotate( a= [90, 0, 0])
    linear_extrude(height = l) polygon(points = [
        [0, 0],
        [w, 0],
        [0, h]
    ], paths=[[0,1,2,0]]);
}

module polyprism(l, w, h) {
polyhedron(
    points=[
        [0,0,h],           // 0    front top corner
        [0,0,0],[w,0,0],   // 1, 2 front left & right bottom corners
        [0,l,h],           // 3    back top corner
        [0,l,0],[w,l,0]    // 4, 5 back left & right bottom corners
    ],faces=[
        [0,2,1],    // top face clockwise looking in
        [3,4,5],    // base face clockwise looking in
        [0,1,4,3],  // h face clockwise looking in
        [1,2,5,4],  //  clockwise looking in
        [0,3,5,2],  //  clockwise looking in
    ]
);

/*DELETE ME*/color([.5,  0,  0, 1])translate([0,0,h])sphere(.5, $fn=8);
// 0 Dark Red
/*DELETE ME*/color([ 0, .5,  0, 1])translate([0,0,0])sphere(.5, $fn=8);
// 1 Dark Green
/*DELETE ME*/color([ 0,  0, .5, 1])translate([w,0,0])sphere(.5, $fn=8);
// 2 Dark Blue
/*DELETE ME*/color([ 1, .5, .5, 1])translate([0,l,h])sphere(.5, $fn=8);
// 3 Light Red
/*DELETE ME*/color([.5,  1, .5, 1])translate([0,l,0])sphere(.5, $fn=8);
// 4 Light Green
/*DELETE ME*/color([.5, .5,  1, 1])translate([w,l,0])sphere(.5, $fn=8);
// 5 Light Blue
}

// Use Preview [F5] to see the colors that will help you associate the
// corners in code with the corners in 3D.
// Use Render [F6] to prove that the faces all render, and therefore
// have their point ordered correctly.

translate([0,0,5]) prism(5, 3, 2); // original prism
polyprism(5, 3, 2); // simplified prism

// NOTE: Polyhedrons require that the points for all faces must be
// ordered clockwise when looking in. If you accidentally get the order
// wrong on one, that face and all subsequent faces will fail to Render.
// However, they will still show up in Preview.
```